### PR TITLE
increase instance memory and add AWS logs agent

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -10,9 +10,9 @@ Mappings:
       Value: playground
   StageVariables:
     CODE:
-      InstanceType: "t4g.nano"
+      InstanceType: "t4g.small"
     PROD:
-      InstanceType: "t4g.nano"
+      InstanceType: "t4g.small"
 
 Parameters:
   CertArn:
@@ -252,3 +252,4 @@ Resources:
             #!/bin/bash -ev
             aws --region ${AWS::Region} s3 cp s3://${DistBucket}/playground/${Stage}/acquisition-health-monitor/acquisition-health-monitor_1.0-SNAPSHOT_all.deb /tmp
             dpkg -i /tmp/acquisition-health-monitor_1.0-SNAPSHOT_all.deb
+            /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/acquisition-health-monitor/application.log '%Y-%m-%dT%H:%M:%S,%f%z'


### PR DESCRIPTION
We had some trouble with instances going unhealthy every hour or so.
We couldn't look at the logs in cloudwatch because the cloudwatch agent wasn't running, so we have added that.

We eventually discovered the java process was being killed due to out of memory, based on some information in /var/log/syslog.
It seemed the nano instance only has 0.5GB, so we are bumping to a small which has 2GB, which matches the standard (at least in the membership account)
instance info here: https://aws.amazon.com/ec2/instance-types/t4/