### PR TITLE
remove metadata section to allow cloudwatch logs agent to work

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -247,8 +247,6 @@ Resources:
       InstanceType: !FindInMap [ StageVariables, !Ref Stage, InstanceType ]
       SecurityGroups:
         - !Ref InstanceSecurityGroup
-      MetadataOptions:
-        HttpTokens: required
       UserData:
         Fn::Base64: !Sub
           - |+


### PR DESCRIPTION
This PR removes the metadata section from the instance.
This will allow the instance to access the credentials in the old (v1) way, which is used by the cloudwatch logs agent.
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

The cloudwatch logs agent seems to use an old version of awscli, which doesn't understand the new (v2) way.

We also noticed the cloudwatch agent [may be deprecated](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html) so there may be a better way to do this in future.