### PR TITLE
Get all pages from AWS cloudwatch and group

### DIFF
--- a/app/com/gu/acquisition_health_monitor/AcquisitionStatusService.scala
+++ b/app/com/gu/acquisition_health_monitor/AcquisitionStatusService.scala
@@ -3,10 +3,10 @@ package com.gu.acquisition_health_monitor
 
 sealed trait AcquisitionStatus
 
-case class AcquisitionStatusSuccess(numberOfRecentAcquisition: Int) extends AcquisitionStatus
+case class AcquisitionStatusSuccess(numberOfRecentAcquisition: Map[String, Int]) extends AcquisitionStatus
 case class AcquisitionStatusError(error: String) extends AcquisitionStatus
 
 trait AcquisitionStatusService {
   // maybe using enum for string
-  def getAcquisitionNumber: Map[String, AcquisitionStatus]
+  def getAcquisitionNumber: AcquisitionStatus
 }

--- a/app/com/gu/acquisition_health_monitor/aws/AwsAcquisitionStatusService.scala
+++ b/app/com/gu/acquisition_health_monitor/aws/AwsAcquisitionStatusService.scala
@@ -4,24 +4,28 @@ import _root_.com.gu.acquisition_health_monitor.{AcquisitionStatus, AcquisitionS
 import com.gu.acquisition_health_monitor.aws.AwsAccess._
 import com.gu.acquisition_health_monitor.aws.AwsCloudWatch.{MetricPeriod, MetricRequest, MetricStats}
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain
+import java.time.Instant
 
 class AwsAcquisitionStatusService(assumeRoleArn: Option[String]) extends AcquisitionStatusService {
   def getCredentialFromAssumeRole: AwsCredentialsProviderChain =
     assumeRoleArn.map(assumeRoleForAws).getOrElse(membershipLocal)
 
-  override def getAcquisitionNumber: Map[String, AcquisitionStatus] = {
+  override def getAcquisitionNumber: AcquisitionStatus = {
     val request = MetricRequest(
       MetricPeriod(60),
-      MetricStats("Sum")
+      MetricStats("Sum"),
+      start = Instant.parse("2022-03-03T10:00:00Z"),
+      endDate = Instant.parse("2022-03-03T16:00:00Z")
     )
 
-    val result = new AwsCloudWatch(getCredentialFromAssumeRole).getAllMetrics(request)
+    val result = new AwsCloudWatch(getCredentialFromAssumeRole).getAllPaymentSuccessMetrics(request)
 
-    val acquisitionStatus = result match {
+    result match {
       case Left(error) => AcquisitionStatusError(error)
-      case Right(dataPoints) => AcquisitionStatusSuccess(dataPoints.head.values.sum.toInt)//TODO
+      case Right(metricsDataPerProduct) => AcquisitionStatusSuccess(metricsDataPerProduct.map { case (successLabel, dataPoints) =>
+        successLabel -> dataPoints.values.sum.toInt
+      })
     }
 
-    Map[String, AcquisitionStatus]("Contribution" ->  acquisitionStatus)
   }
 }

--- a/app/com/gu/acquisition_health_monitor/aws/AwsAcquisitionStatusService.scala
+++ b/app/com/gu/acquisition_health_monitor/aws/AwsAcquisitionStatusService.scala
@@ -19,7 +19,7 @@ class AwsAcquisitionStatusService(assumeRoleArn: Option[String]) extends Acquisi
 
     val acquisitionStatus = result match {
       case Left(error) => AcquisitionStatusError(error)
-      case Right(dataPoints) => AcquisitionStatusSuccess(dataPoints.head.values.sum.toInt)
+      case Right(dataPoints) => AcquisitionStatusSuccess(dataPoints.head.values.sum.toInt)//TODO
     }
 
     Map[String, AcquisitionStatus]("Contribution" ->  acquisitionStatus)

--- a/app/com/gu/acquisition_health_monitor/aws/AwsCloudWatchMetricGet.scala
+++ b/app/com/gu/acquisition_health_monitor/aws/AwsCloudWatchMetricGet.scala
@@ -1,15 +1,14 @@
 package com.gu.acquisition_health_monitor.aws
 
-import com.gu.acquisition_health_monitor.aws.AwsCloudWatch.{MetricDimensionName, MetricDimensionValue, MetricName, MetricNamespace, MetricPeriod, MetricRequest, MetricStats, buildMetricRequest}
-import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, EnvironmentVariableCredentialsProvider, ProfileCredentialsProvider}
+import com.gu.acquisition_health_monitor.aws.AwsCloudWatch.{MetricRequest, MetricRequestBuilder}
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
-import software.amazon.awssdk.services.cloudwatch.model.{Dimension, DimensionFilter, GetMetricDataRequest, GetMetricDataResponse, GetMetricStatisticsRequest, ListMetricsRequest, ListMetricsResponse, Metric, MetricDataQuery, MetricDataResult, MetricDatum, MetricStat, PutMetricDataRequest, StandardUnit}
+import software.amazon.awssdk.services.cloudwatch.model._
 
-import scala.jdk.CollectionConverters._
 import java.time.Instant
-import scala.collection.View.Empty
-import scala.util.{Failure, Success, Try}
+import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 
 
@@ -22,34 +21,31 @@ class AwsCloudWatch(credential:  AwsCredentialsProviderChain) {
 
   println(s"client: ${client}")
 
-  private def listMetrics(): Either[String, ListMetricsResponse] = {
+  private def listPaymentSuccessMetrics(): Either[String, ListMetricsResponse] = {
     val listMetricsRequest: ListMetricsRequest = ListMetricsRequest.builder()
       .namespace("support-frontend")
       .metricName("PaymentSuccess")
       .dimensions(DimensionFilter.builder.name("Stage").value("PROD").build())
-      .build();
-    val failableResult = Try {
+      .build()
+    Try {
       client.listMetrics(listMetricsRequest)
     }.toEither.left.map(x => x.toString)
-
-    failableResult
   }
 
-  def getAllMetrics(request: MetricRequest): Either[String, List[Map[Instant, Double]]]= {
+  def getAllPaymentSuccessMetrics(request: MetricRequest): Either[String, Map[String, Map[Instant, Double]]]= {
     for {
-      listOfAllMetrics <- listMetrics()
-      allMetrics <- metricGet(request, None, listOfAllMetrics, Nil)
-    } yield AwsToScala(allMetrics)
+      listOfAllMetrics <- listPaymentSuccessMetrics()
+      allMetrics <- getMetricDataFromMetrics(new MetricRequestBuilder(request, listOfAllMetrics), None, Nil)
+    } yield groupMetricDataByProduct(allMetrics)
   }
 
-  def metricGet(
-    request: MetricRequest,
+  def getMetricDataFromMetrics(
+    metricRequestBuilder: MetricRequestBuilder,
     nextToken: Option[String],
-    listMetricsResponse: ListMetricsResponse,
     soFar: List[GetMetricDataResponse]
   ): Either[String, List[GetMetricDataResponse]] = {
 
-    val metricDataRequest: GetMetricDataRequest = buildMetricRequest(request, listMetricsResponse, nextToken)
+    val metricDataRequest: GetMetricDataRequest = metricRequestBuilder.build(nextToken)
 
     val failableResult = Try {
       client.getMetricData(metricDataRequest)
@@ -59,25 +55,32 @@ class AwsCloudWatch(credential:  AwsCredentialsProviderChain) {
       value <- failableResult
       metricResults <- Option(value.nextToken) match {
         case Some(next) =>
-          metricGet(request, Some(next), listMetricsResponse, value :: soFar)
+          getMetricDataFromMetrics(metricRequestBuilder, Some(next), value :: soFar)
         case None =>
          Right((value :: soFar).reverse)
       }
     } yield metricResults
   }
 
-  private def AwsToScala(responses: List[GetMetricDataResponse]) =
-    for {
-      response <- responses
-      metricResult <- response.metricDataResults().asScala.toList
+  private def groupMetricDataByProduct(responsePages: List[GetMetricDataResponse]) = {
+    val pagesData: List[(String, Map[Instant, Double])] = for {
+      page <- responsePages
+      singleMetricDataForPage <- page.metricDataResults().asScala.toList
     } yield {
-      println("value size: " + metricResult.values.size) // FIXME use the logger properly so it goes into the right place
-      println("The label is " + metricResult.label())
-      println("The status code is " + metricResult.statusCode().toString())
-      val timestamps = metricResult.timestamps().asScala.toList
-      val values = metricResult.values().asScala.toList.map(x => x.toDouble)
-      timestamps.zip(values).toMap
+      println("value size: " + singleMetricDataForPage.values.size) // FIXME use the logger properly so it goes into the right place
+      println("The label is " + singleMetricDataForPage.label())
+      println("The status code is " + singleMetricDataForPage.statusCode().toString())
+      val timestamps = singleMetricDataForPage.timestamps().asScala.toList
+      val values = singleMetricDataForPage.values().asScala.toList.map(x => x.toDouble)
+      val valuesForPage = timestamps.zip(values).toMap
+      val labelForMetric = singleMetricDataForPage.label()
+      (labelForMetric, valuesForPage)
     }
+    // at this point, we have one record for each page and each metric.  So for 2 pages and 4 metrics we would have
+    // 8 records.
+    // next we need to merge together the data with the same label
+    pagesData.groupMapReduce(_._1)(_._2)(_ concat _) // TODO might we get duplicate "Instant"s? check AWS docs
+  }
 
 }
 
@@ -95,7 +98,12 @@ object AwsCloudWatch {
 
   case class MetricPeriod(value: Int) extends AnyVal
 
-  case class MetricRequest(period: MetricPeriod, stat: MetricStats)
+  case class MetricRequest(
+    period: MetricPeriod,
+    stat: MetricStats,
+    start: Instant,
+    endDate: Instant,
+  )
 
   private def getLabelFromDimension(id: Int, dimensions: List[Dimension]) = {
 
@@ -105,35 +113,33 @@ object AwsCloudWatch {
     label1 + "-" + label2
   }
 
-  private[aws] def buildMetricRequest(request: MetricRequest, listMetricResponse: ListMetricsResponse, nextToken: Option[String]): GetMetricDataRequest = {
+  private class MetricRequestBuilder(request: MetricRequest, listMetricResponse: ListMetricsResponse) {
 
-    //println("Now: " + Instant.now())
-    val start = Instant.parse("2022-03-03T10:00:00Z")
-    val endDate = Instant.parse("2022-03-03T16:00:00Z")
+    def build(nextToken: Option[String]): GetMetricDataRequest = {
 
+      val queries = listMetricResponse.metrics().asScala.zipWithIndex.map {
+        case (metric, index) => {
+          val metricStat = MetricStat.builder
+            .stat(request.stat.value)
+            .period(request.period.value)
+            .metric(metric)
+            .build()
 
-    val queries = listMetricResponse.metrics().asScala.zipWithIndex.map {
-      case (metric, index) => {
-        val metricStat = MetricStat.builder
-          .stat(request.stat.value)
-          .period(request.period.value)
-          .metric(metric)
-          .build()
-
-        MetricDataQuery.builder
-          .metricStat(metricStat)
-          .id("id" + index)
-          .label(getLabelFromDimension(index, metric.dimensions().asScala.toList))
-          .returnData(true).build()
+          MetricDataQuery.builder
+            .metricStat(metricStat)
+            .id("id" + index)
+            .label(getLabelFromDimension(index, metric.dimensions().asScala.toList))
+            .returnData(true).build()
+        }
       }
-    }
 
-    GetMetricDataRequest.builder
-      //.maxDatapoints(200)
-      .startTime(start)
-      .endTime(endDate)
-      .metricDataQueries(queries.asJava)
-      .nextToken(nextToken.orNull)
-      .build()
+      GetMetricDataRequest.builder
+        //.maxDatapoints(200)
+        .startTime(request.start)
+        .endTime(request.endDate)
+        .metricDataQueries(queries.asJava)
+        .nextToken(nextToken.orNull)
+        .build()
+    }
   }
 }

--- a/app/com/gu/acquisition_health_monitor/mocks/DummyAcquisitionStatusService.scala
+++ b/app/com/gu/acquisition_health_monitor/mocks/DummyAcquisitionStatusService.scala
@@ -3,9 +3,6 @@ package com.gu.acquisition_health_monitor.mocks
 import com.gu.acquisition_health_monitor.{AcquisitionStatus, AcquisitionStatusService, AcquisitionStatusSuccess}
 
 object DummyAcquisitionStatusService extends AcquisitionStatusService {
-  override def getAcquisitionNumber: Map[String, AcquisitionStatus] = {
-    val dummyAcquisitionStatus = AcquisitionStatusSuccess(22)
+  override def getAcquisitionNumber: AcquisitionStatus = AcquisitionStatusSuccess(Map("dummy" -> 22))
 
-    Map("acquisition1" -> dummyAcquisitionStatus)
-  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
 libraryDependencies += ws
 libraryDependencies += "com.gu" %% "simple-configuration-ssm" % "1.5.7"
-libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.4"
-libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.2"
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.6"
+libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.6"
 
 enablePlugins(SystemdPlugin, PlayScala, RiffRaffArtifact, JDebPackaging)
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")
 
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.11.0")
 


### PR DESCRIPTION
This PR fetches all metrics from all pages that match PaymentSuccess, and returns to the client as a toString body
example
```
AcquisitionStatusSuccess(HashMap(Contribution-PayPal -> 92, GuardianWeekly-PayPal -> 4, Paper-PayPal -> 0, Contribution-StripeApplePay -> 27, DigitalPack-PayPal -> 16, GuardianWeekly-DirectDebit -> 0, Contribution-Stripe -> 117, Paper-Stripe -> 1, DigitalPack-DirectDebit -> 11, Contribution-Existing -> 0, Paper-DirectDebit -> 0, GuardianWeekly-Stripe -> 5, Contribution-DirectDebit -> 22, DigitalPack-Stripe -> 33))
```

TODO add some tests!